### PR TITLE
Fix pgrep for macos

### DIFF
--- a/filtering.sh
+++ b/filtering.sh
@@ -19,7 +19,7 @@ filter_bash_history() {
 
   # remove trivial commands
   sed -r '/^#[0-9]* .{,6}$/d' |
-  sed -r '/^#[0-9]* [a-Z0-9 _/.]{,12}$/d' |
+  sed -r '/^#[0-9]* [a-zA-Z0-9 _/.]{,12}$/d' |
 
   # sort by timestamp
   sort --stable --key=1,1 |

--- a/synchronization.sh
+++ b/synchronization.sh
@@ -31,7 +31,7 @@ flush_current_session_history() { __merge_history_file "${HISTFILE}.$$"; }
 trap flush_current_session_history EXIT
 
 # detect leftover files from crashed sessions and merge them back
-active_shells=$(pgrep `ps -p $$ -o comm=`)
+active_shells=$(pgrep -- "$(ps -p $$ -o comm=)")
 grep_pattern=$(for pid in $active_shells; do echo -n "-e \.${pid}\$ "; done)
 orphaned_files=$(ls $HISTFILE.[0-9]* 2>/dev/null | grep -v $grep_pattern)
 


### PR DESCRIPTION
Closes #2 

- Executing pgrep on macos fails due to pgrep thinking we are sending a parameter instead of the pattern:
    ```sh
    → (set -x; pgrep `ps -p $$ -o comm=`)
    ++ ps -p 4662 -o comm=
    + pgrep -bash
    pgrep: illegal option -- b
    usage: pgrep [-Lfilnoqvx] [-d delim] [-F pidfile] [-G gid]
                [-P ppid] [-U uid] [-g pgrp]
                [-t tty] [-u euid] pattern ...
    ```

- Run on MacOS (multiple sessions due to tmux):
    ```sh
    → uname -s
    Darwin

    → (set -x; pgrep -- "$(ps -p $$ -o comm=)")
    ++ ps -p 4662 -o comm=
    + pgrep -- -bash
    2308
    2345
    2388
    2448
    2591
    2752
    53888
    ```

- This PR fixes the issue and ensure compatibility with common linux distros:
    ```sh
    → docker run --rm -it ubuntu bash -c 'set -x; pgrep -- "$(ps -p $$ -o comm=)"'
    ++ ps -p 1 -o comm=
    + pgrep -- bash
    1

    → docker run --rm -it centos bash -c 'set -x; pgrep -- "$(ps -p $$ -o comm=)"'
    ++ ps -p 1 -o comm=
    + pgrep -- bash
    1
    ```